### PR TITLE
schema globals

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-text",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "framework": "^2.0.0",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-text",
   "issues": "https://adaptlearning.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10100&issuetype=1&priority=6&components=10502",

--- a/properties.schema
+++ b/properties.schema
@@ -3,6 +3,15 @@
   "$schema": "http://json-schema.org/draft-04/schema",
   "id": "http://jsonschema.net",
   "$ref": "http://localhost/plugins/content/component/model.schema",
+  "globals": {
+    "ariaRegion": {
+      "type": "string",
+      "required": true,
+      "default": "",
+      "inputType": "Text",
+      "validators": []
+    }
+  },
   "properties":{
     "_supportedLayout": {
       "type": "string",


### PR DESCRIPTION
Gives the option to add ariaRegion text in the authoring tool. No default text has been set.